### PR TITLE
Add pi-precision explorer to Gaming & Misc projects

### DIFF
--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -5,8 +5,8 @@ import { cn } from "@/lib/utils"
 
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & { thumbLabel?: string }
+>(({ className, thumbLabel, ...props }, ref) => (
   <SliderPrimitive.Root
     ref={ref}
     className={cn("relative flex w-full touch-none select-none items-center", className)}
@@ -16,6 +16,7 @@ const Slider = React.forwardRef<
       <SliderPrimitive.Range className="absolute h-full bg-primary" />
     </SliderPrimitive.Track>
     <SliderPrimitive.Thumb
+      aria-label={thumbLabel}
       className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
   </SliderPrimitive.Root>
 ))

--- a/src/data/gaming-projects.ts
+++ b/src/data/gaming-projects.ts
@@ -2,12 +2,24 @@ export interface GamingProject {
   id: string;
   title: string;
   description: string;
+  /** Combined with /projects/gaming/ to build this project's own page. Mutually exclusive with `url`. */
+  slug?: string;
   url?: string;
   technologies?: string[];
 }
 
-// Nothing published here yet. A good first candidate: the Big Pharma
-// save-file calculator/simulator built in origin/2021-rework and
-// origin/2022 — a real, well-built ingredient/effect/product-line engine
-// for the video game Big Pharma, never ported forward into this rewrite.
-export const gamingProjects: GamingProject[] = [];
+// A good future candidate: the Big Pharma save-file calculator/simulator
+// built in origin/2021-rework and origin/2022 — a real, well-built
+// ingredient/effect/product-line engine for the video game Big Pharma,
+// never ported forward into this rewrite.
+export const gamingProjects: GamingProject[] = [
+  {
+    id: "pi-precision",
+    slug: "pi-precision",
+    title: "How Much Pi Do You Need?",
+    description:
+      "Truncate pi to as few or as many digits as you like and watch the resulting position error ripple across " +
+      "the solar system — from Mercury out to the edge of the observable universe.",
+    technologies: ["React", "TypeScript", "decimal.js"],
+  },
+];

--- a/src/games/pi-precision/components/PiPrecisionExplorer.tsx
+++ b/src/games/pi-precision/components/PiPrecisionExplorer.tsx
@@ -1,0 +1,136 @@
+import { useMemo, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Slider } from "@/components/ui/slider";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { celestialBodies } from "../engine/celestialBodies";
+import { piDigitsString } from "../engine/pi";
+import { minDigitsForTargetError, positionErrorKm } from "../engine/precision";
+import { formatLengthKm, scaleComparison } from "../engine/format";
+import { targetPrecisions } from "../engine/targetPrecisions";
+
+const MIN_DIGITS = 1;
+const MAX_DIGITS = 45;
+const DEFAULT_DIGITS = 6;
+const DEFAULT_TARGET_ID = "1km";
+
+export default function PiPrecisionExplorer() {
+  const [digits, setDigits] = useState(DEFAULT_DIGITS);
+  const [targetId, setTargetId] = useState(DEFAULT_TARGET_ID);
+
+  const target = targetPrecisions.find((t) => t.id === targetId) ?? targetPrecisions[0];
+  const piString = piDigitsString(digits);
+
+  const rows = useMemo(
+    () =>
+      celestialBodies.map((body) => {
+        const errorKm = positionErrorKm(digits, body.distanceKm);
+        const digitsNeeded = minDigitsForTargetError(body.distanceKm, target.km);
+        const meetsTarget = errorKm <= target.km;
+        return { body, errorKm, digitsNeeded, meetsTarget };
+      }),
+    [digits, target]
+  );
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Digits of &pi; you're using</CardTitle>
+          <CardDescription>
+            Drag to see how a planet's calculated position drifts when &pi; is truncated to fewer digits.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="rounded-lg border bg-muted/30 px-4 py-3 font-mono text-lg sm:text-xl tracking-wide">
+            &pi; &asymp; {piString}
+          </div>
+          <Slider
+            min={MIN_DIGITS}
+            max={MAX_DIGITS}
+            step={1}
+            value={[digits]}
+            onValueChange={([value]) => setDigits(value)}
+            thumbLabel="Digits of pi"
+          />
+          <div className="flex justify-between text-sm text-muted-foreground">
+            <span>{MIN_DIGITS} digit</span>
+            <span className="font-medium text-foreground">{digits} digits</span>
+            <span>{MAX_DIGITS} digits</span>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Target precision</CardTitle>
+          <CardDescription>
+            How accurately do you want to know a body's position? The table below shows the minimum digits of &pi;
+            that achieve it — and whether your current slider setting already gets there.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Select value={targetId} onValueChange={setTargetId}>
+            <SelectTrigger className="w-full sm:w-96">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {targetPrecisions.map((t) => (
+                <SelectItem key={t.id} value={t.id}>
+                  {t.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Position error by body</CardTitle>
+          <CardDescription>
+            Worst-case drift in a body's computed orbital position, treating its orbit as circular.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Body</TableHead>
+                <TableHead>Distance</TableHead>
+                <TableHead>Digits needed for target</TableHead>
+                <TableHead>Error at {digits} digits</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map(({ body, errorKm, digitsNeeded, meetsTarget }) => (
+                <TableRow key={body.id}>
+                  <TableCell className="font-medium">{body.name}</TableCell>
+                  <TableCell className="text-muted-foreground">{body.distanceLabel}</TableCell>
+                  <TableCell>{digitsNeeded ?? `>${MAX_DIGITS}`}</TableCell>
+                  <TableCell>
+                    <div>{formatLengthKm(errorKm)}</div>
+                    <div className="text-xs text-muted-foreground">{scaleComparison(errorKm)}</div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={meetsTarget ? "default" : "outline"}>
+                      {meetsTarget ? "within target" : "falls short"}
+                    </Badge>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/games/pi-precision/engine/celestialBodies.ts
+++ b/src/games/pi-precision/engine/celestialBodies.ts
@@ -1,0 +1,51 @@
+export type CelestialBodyCategory = "planet" | "dwarf-planet" | "probe" | "star" | "galaxy" | "universe";
+
+export interface CelestialBody {
+  id: string;
+  name: string;
+  category: CelestialBodyCategory;
+  /** Distance from the Sun (or, for the last few entries, from Earth), in kilometers. */
+  distanceKm: number;
+  /** Human-scale distance for display — kept as a fixed label since the natural unit (AU, ly) varies by scale. */
+  distanceLabel: string;
+}
+
+const AU_KM = 149_597_870;
+const LIGHT_YEAR_KM = 9_460_730_472_580.8;
+
+// Semi-major axes for planets/dwarf planets (JPL/IAU reference values); Voyager
+// 1's distance is approximate and grows daily, given here as of ~2025.
+// Distances beyond the solar system are approximate by nature.
+export const celestialBodies: CelestialBody[] = [
+  { id: "mercury", name: "Mercury", category: "planet", distanceKm: 0.387 * AU_KM, distanceLabel: "0.39 AU" },
+  { id: "venus", name: "Venus", category: "planet", distanceKm: 0.723 * AU_KM, distanceLabel: "0.72 AU" },
+  { id: "earth", name: "Earth", category: "planet", distanceKm: 1 * AU_KM, distanceLabel: "1 AU" },
+  { id: "mars", name: "Mars", category: "planet", distanceKm: 1.524 * AU_KM, distanceLabel: "1.52 AU" },
+  { id: "jupiter", name: "Jupiter", category: "planet", distanceKm: 5.203 * AU_KM, distanceLabel: "5.20 AU" },
+  { id: "saturn", name: "Saturn", category: "planet", distanceKm: 9.537 * AU_KM, distanceLabel: "9.54 AU" },
+  { id: "uranus", name: "Uranus", category: "planet", distanceKm: 19.191 * AU_KM, distanceLabel: "19.2 AU" },
+  { id: "neptune", name: "Neptune", category: "planet", distanceKm: 30.069 * AU_KM, distanceLabel: "30.1 AU" },
+  { id: "pluto", name: "Pluto", category: "dwarf-planet", distanceKm: 39.482 * AU_KM, distanceLabel: "39.5 AU" },
+  { id: "voyager-1", name: "Voyager 1", category: "probe", distanceKm: 167 * AU_KM, distanceLabel: "~167 AU (2025)" },
+  {
+    id: "proxima-centauri",
+    name: "Proxima Centauri",
+    category: "star",
+    distanceKm: 4.2465 * LIGHT_YEAR_KM,
+    distanceLabel: "4.25 light-years",
+  },
+  {
+    id: "milky-way-diameter",
+    name: "Milky Way (diameter)",
+    category: "galaxy",
+    distanceKm: 100_000 * LIGHT_YEAR_KM,
+    distanceLabel: "~100,000 light-years",
+  },
+  {
+    id: "observable-universe",
+    name: "Edge of the observable universe",
+    category: "universe",
+    distanceKm: 46_500_000_000 * LIGHT_YEAR_KM,
+    distanceLabel: "~46.5 billion light-years",
+  },
+];

--- a/src/games/pi-precision/engine/format.spec.ts
+++ b/src/games/pi-precision/engine/format.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { formatLengthKm, scaleComparison } from "./format";
+
+describe("formatLengthKm", () => {
+  it("formats zero", () => {
+    expect(formatLengthKm(0)).toBe("0 m");
+  });
+
+  it("picks a sensible SI prefix across a wide dynamic range", () => {
+    expect(formatLengthKm(1)).toBe("1 km");
+    expect(formatLengthKm(1000)).toBe("1 Mm");
+    expect(formatLengthKm(1e-6)).toBe("1 mm");
+    expect(formatLengthKm(1e-12)).toBe("1 nm");
+  });
+
+  it("rounds to a small number of significant figures", () => {
+    expect(formatLengthKm(1.23456)).toMatch(/^1\.23 km$/);
+  });
+});
+
+describe("scaleComparison", () => {
+  it("returns an atom-scale comparison for picometer-scale lengths", () => {
+    expect(scaleComparison(1e-13)).toMatch(/atom/);
+  });
+
+  it("returns a solar-system-scale comparison for AU-scale lengths", () => {
+    expect(scaleComparison(1.5e8)).toMatch(/Sun|solar system/);
+  });
+
+  it("falls back gracefully beyond the largest reference", () => {
+    expect(scaleComparison(1e30)).toBe("larger than the Milky Way");
+  });
+});

--- a/src/games/pi-precision/engine/format.ts
+++ b/src/games/pi-precision/engine/format.ts
@@ -1,0 +1,72 @@
+const SI_PREFIXES: { exp: number; symbol: string }[] = [
+  { exp: 24, symbol: "Y" },
+  { exp: 21, symbol: "Z" },
+  { exp: 18, symbol: "E" },
+  { exp: 15, symbol: "P" },
+  { exp: 12, symbol: "T" },
+  { exp: 9, symbol: "G" },
+  { exp: 6, symbol: "M" },
+  { exp: 3, symbol: "k" },
+  { exp: 0, symbol: "" },
+  { exp: -3, symbol: "m" },
+  { exp: -6, symbol: "µ" },
+  { exp: -9, symbol: "n" },
+  { exp: -12, symbol: "p" },
+  { exp: -15, symbol: "f" },
+  { exp: -18, symbol: "a" },
+  { exp: -21, symbol: "z" },
+  { exp: -24, symbol: "y" },
+];
+
+function significantFigures(value: number, figures = 3): string {
+  if (value === 0) return "0";
+  return value.toLocaleString(undefined, { maximumSignificantDigits: figures, minimumSignificantDigits: 1 });
+}
+
+/** Formats a length given in kilometers using the best-fit SI prefix on meters. */
+export function formatLengthKm(km: number): string {
+  const meters = km * 1000;
+  if (meters === 0) return "0 m";
+
+  const rawExp = Math.floor(Math.log10(Math.abs(meters)) / 3) * 3;
+  const clampedExp = Math.max(-24, Math.min(24, rawExp));
+  const prefix = SI_PREFIXES.find((p) => p.exp === clampedExp) ?? SI_PREFIXES[SI_PREFIXES.length - 1];
+  const scaled = meters / 10 ** prefix.exp;
+  return `${significantFigures(scaled)} ${prefix.symbol}m`;
+}
+
+interface ScaleReference {
+  maxMeters: number;
+  label: string;
+}
+
+// Ascending thresholds; the first one a length is <= to is used. Meant as
+// evocative, order-of-magnitude comparisons, not precise equivalences.
+const SCALE_REFERENCES: ScaleReference[] = [
+  { maxMeters: 1e-15, label: "smaller than a proton" },
+  { maxMeters: 1e-10, label: "about the size of an atom" },
+  { maxMeters: 2e-9, label: "about the width of a strand of DNA" },
+  { maxMeters: 1e-6, label: "about the size of a bacterium" },
+  { maxMeters: 7e-5, label: "about the width of a human hair" },
+  { maxMeters: 5e-4, label: "about the thickness of a credit card" },
+  { maxMeters: 5e-3, label: "about the width of a grain of rice" },
+  { maxMeters: 3e-2, label: "about the width of a golf ball" },
+  { maxMeters: 0.3, label: "about the length of a football" },
+  { maxMeters: 2, label: "about the height of a doorway" },
+  { maxMeters: 100, label: "about the length of a football field" },
+  { maxMeters: 10_000, label: "about the length of Manhattan Island" },
+  { maxMeters: 1_000_000, label: "about the width of a small country" },
+  { maxMeters: 1e7, label: "about the diameter of Earth" },
+  { maxMeters: 1e9, label: "about the distance to the Moon" },
+  { maxMeters: 1.5e11, label: "about the distance to the Sun" },
+  { maxMeters: 6e12, label: "about the diameter of the solar system" },
+  { maxMeters: 9.461e16, label: "about the width of a light-year" },
+  { maxMeters: 9.461e20, label: "about the width of the Milky Way" },
+];
+
+/** A short, evocative real-world comparison for a length given in kilometers. */
+export function scaleComparison(km: number): string {
+  const meters = Math.abs(km) * 1000;
+  const match = SCALE_REFERENCES.find((ref) => meters <= ref.maxMeters);
+  return match ? match.label : "larger than the Milky Way";
+}

--- a/src/games/pi-precision/engine/pi.spec.ts
+++ b/src/games/pi-precision/engine/pi.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { MAX_PI_DIGITS, piDigitsString, piTruncationError, piValue } from "./pi";
+
+describe("piDigitsString", () => {
+  it("returns just the leading digit for 1 digit", () => {
+    expect(piDigitsString(1)).toBe("3");
+  });
+
+  it("truncates (does not round) at the requested digit count", () => {
+    expect(piDigitsString(4)).toBe("3.141");
+    expect(piDigitsString(6)).toBe("3.14159");
+  });
+
+  it("clamps below 1 and above MAX_PI_DIGITS", () => {
+    expect(piDigitsString(0)).toBe(piDigitsString(1));
+    expect(piDigitsString(-5)).toBe(piDigitsString(1));
+    expect(piDigitsString(MAX_PI_DIGITS + 10)).toBe(piDigitsString(MAX_PI_DIGITS));
+  });
+});
+
+describe("piValue", () => {
+  it("matches Math.PI to within its own truncation error for digit counts within double precision", () => {
+    expect(piValue(15)).toBeCloseTo(Math.PI, 13);
+  });
+});
+
+describe("piTruncationError", () => {
+  it("shrinks monotonically as digits increase", () => {
+    let previous = piTruncationError(1);
+    for (let digits = 2; digits <= 20; digits++) {
+      const error = piTruncationError(digits);
+      expect(error).toBeLessThan(previous);
+      previous = error;
+    }
+  });
+
+  it("is exactly zero at MAX_PI_DIGITS", () => {
+    expect(piTruncationError(MAX_PI_DIGITS)).toBe(0);
+  });
+
+  it("is on the order of 10^-2 for 3 digits (3.14 vs pi)", () => {
+    const error = piTruncationError(3);
+    expect(error).toBeGreaterThan(0.001);
+    expect(error).toBeLessThan(0.01);
+  });
+});

--- a/src/games/pi-precision/engine/pi.ts
+++ b/src/games/pi-precision/engine/pi.ts
@@ -1,0 +1,35 @@
+import Decimal from "decimal.js";
+
+// 50 decimal digits of pi — far more than enough to illustrate truncation
+// error at any distance in the observable universe, since ~40 digits already
+// gives sub-atomic precision at that scale.
+const PI_STRING = "3.14159265358979323846264338327950288419716939937510";
+
+Decimal.set({ precision: 60 });
+const PI_EXACT = new Decimal(PI_STRING);
+
+/** Total significant digits available in PI_STRING, including the leading "3". */
+export const MAX_PI_DIGITS = PI_STRING.replace(".", "").length;
+
+/**
+ * Pi truncated (not rounded) to `digits` significant digits, counting the
+ * leading "3" as the first digit — so piDigitsString(1) is "3" and
+ * piDigitsString(4) is "3.142"... no: truncation, so piDigitsString(4) is "3.141".
+ */
+export function piDigitsString(digits: number): string {
+  const clamped = Math.max(1, Math.min(Math.floor(digits), MAX_PI_DIGITS));
+  return clamped === 1 ? "3" : PI_STRING.slice(0, clamped + 1);
+}
+
+export function piDecimal(digits: number): Decimal {
+  return new Decimal(piDigitsString(digits));
+}
+
+export function piValue(digits: number): number {
+  return piDecimal(digits).toNumber();
+}
+
+/** Absolute error between true pi and pi truncated to `digits` significant digits. */
+export function piTruncationError(digits: number): number {
+  return PI_EXACT.minus(piDecimal(digits)).abs().toNumber();
+}

--- a/src/games/pi-precision/engine/precision.spec.ts
+++ b/src/games/pi-precision/engine/precision.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { MAX_PI_DIGITS } from "./pi";
+import { minDigitsForTargetError, positionErrorKm } from "./precision";
+
+describe("positionErrorKm", () => {
+  it("is zero once pi is exact", () => {
+    expect(positionErrorKm(MAX_PI_DIGITS, 1e9)).toBe(0);
+  });
+
+  it("scales linearly with distance for a fixed digit count", () => {
+    const a = positionErrorKm(5, 1_000_000);
+    const b = positionErrorKm(5, 2_000_000);
+    expect(b).toBeCloseTo(a * 2, 6);
+  });
+
+  it("shrinks as digit count increases for a fixed distance", () => {
+    let previous = positionErrorKm(1, 1e9);
+    for (let digits = 2; digits <= 15; digits++) {
+      const error = positionErrorKm(digits, 1e9);
+      expect(error).toBeLessThan(previous);
+      previous = error;
+    }
+  });
+
+  it("matches the known JPL reference point: pi to 15 decimal places over a 25-billion-mile-diameter circle is off by under 1.5 inches", () => {
+    // JPL's own worked example (see the NASA/JPL Edu "How many decimals of pi
+    // do we really need?" piece): a circle as wide as Voyager 1's orbit
+    // (~25 billion miles in diameter) computed with pi truncated to 15
+    // decimal places is off by less than 1.5 inches. "15 decimal places" is
+    // 16 significant digits in this module's counting (which includes the
+    // leading "3"), and positionErrorKm takes a radius, so pass half the
+    // 25-billion-mile diameter, converted to km.
+    const radiusKm = ((25_000_000_000 * 1.609344) / 2);
+    const errorMeters = positionErrorKm(16, radiusKm) * 1000;
+    expect(errorMeters).toBeLessThan(1.5 * 0.0254);
+  });
+});
+
+describe("minDigitsForTargetError", () => {
+  it("finds the minimum digits needed to hit a coarse target quickly", () => {
+    // At Earth's distance (~1 AU), 3 digits of pi (3.14) already gets well
+    // within a million km.
+    const digits = minDigitsForTargetError(149_597_870, 1_000_000);
+    expect(digits).not.toBeNull();
+    expect(digits!).toBeLessThanOrEqual(4);
+  });
+
+  it("returns a digit count whose error is under the target, and one fewer digit's error is not", () => {
+    const distanceKm = 5_906_380_000; // Pluto
+    const targetKm = 1;
+    const digits = minDigitsForTargetError(distanceKm, targetKm);
+    expect(digits).not.toBeNull();
+    expect(positionErrorKm(digits!, distanceKm)).toBeLessThanOrEqual(targetKm);
+    if (digits! > 1) {
+      expect(positionErrorKm(digits! - 1, distanceKm)).toBeGreaterThan(targetKm);
+    }
+  });
+
+  it("returns null for a target error that's negative and therefore unreachable", () => {
+    expect(minDigitsForTargetError(1e9, -1)).toBeNull();
+  });
+
+  it("needs close to the full ~40 digits JPL cites to resolve the observable universe to sub-atomic scale", () => {
+    const observableUniverseKm = 46_500_000_000 * 9_460_730_472_580.8;
+    const digits = minDigitsForTargetError(observableUniverseKm, 1e-15); // 1 picometer, in km
+    expect(digits).not.toBeNull();
+    expect(digits!).toBeGreaterThan(35);
+    expect(digits!).toBeLessThanOrEqual(45);
+  });
+});

--- a/src/games/pi-precision/engine/precision.ts
+++ b/src/games/pi-precision/engine/precision.ts
@@ -1,0 +1,31 @@
+import { MAX_PI_DIGITS, piTruncationError } from "./pi";
+
+/**
+ * Worst-case positional error introduced by using pi truncated to `digits`
+ * significant digits when computing where a body sits along its orbit.
+ *
+ * A body's position along its orbit is found from an angle like
+ * theta = 2*pi*f (f = fraction of the orbit completed since some reference
+ * point). Treating the orbit as circular, that angle's sensitivity to pi is
+ * d(theta)/d(pi) = 2f, maximized at f -> 1 (a full trip around). So the
+ * worst-case arc-length error at radius r is r * 2 * (error in pi) — the same
+ * relationship JPL uses for circumference (C = pi*d): the error in a full
+ * loop around a circle of radius r scales with its diameter, not its radius.
+ */
+export function positionErrorKm(digits: number, distanceKm: number): number {
+  return 2 * distanceKm * piTruncationError(digits);
+}
+
+/**
+ * Smallest digit count (of significant digits of pi, 1..MAX_PI_DIGITS) whose
+ * resulting position error at `distanceKm` is at or under `targetErrorKm`.
+ * Returns null if even the maximum supported precision isn't enough.
+ */
+export function minDigitsForTargetError(distanceKm: number, targetErrorKm: number): number | null {
+  for (let digits = 1; digits <= MAX_PI_DIGITS; digits++) {
+    if (positionErrorKm(digits, distanceKm) <= targetErrorKm) {
+      return digits;
+    }
+  }
+  return null;
+}

--- a/src/games/pi-precision/engine/targetPrecisions.spec.ts
+++ b/src/games/pi-precision/engine/targetPrecisions.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { targetPrecisions } from "./targetPrecisions";
+
+describe("targetPrecisions", () => {
+  it("has unique ids and strictly decreasing km values (coarsest first)", () => {
+    const ids = new Set(targetPrecisions.map((t) => t.id));
+    expect(ids.size).toBe(targetPrecisions.length);
+
+    for (let i = 1; i < targetPrecisions.length; i++) {
+      expect(targetPrecisions[i].km).toBeLessThan(targetPrecisions[i - 1].km);
+    }
+  });
+});

--- a/src/games/pi-precision/engine/targetPrecisions.ts
+++ b/src/games/pi-precision/engine/targetPrecisions.ts
@@ -1,0 +1,21 @@
+export interface TargetPrecision {
+  id: string;
+  label: string;
+  km: number;
+}
+
+// Ordered coarsest-to-finest so a <Select> lists them in a natural progression.
+export const targetPrecisions: TargetPrecision[] = [
+  { id: "1000km", label: "Nearest 1,000 km", km: 1_000 },
+  { id: "100km", label: "Nearest 100 km", km: 100 },
+  { id: "10km", label: "Nearest 10 km", km: 10 },
+  { id: "1km", label: "Nearest 1 km", km: 1 },
+  { id: "100m", label: "Nearest 100 m", km: 0.1 },
+  { id: "10m", label: "Nearest 10 m", km: 0.01 },
+  { id: "1m", label: "Nearest 1 m", km: 0.001 },
+  { id: "1cm", label: "Nearest 1 cm", km: 0.00001 },
+  { id: "1mm", label: "Nearest 1 mm", km: 0.000001 },
+  { id: "1um", label: "Nearest 1 µm — about the size of a bacterium", km: 1e-9 },
+  { id: "1nm", label: "Nearest 1 nm — about the width of a DNA strand", km: 1e-12 },
+  { id: "atom", label: "Nearest atom's width (~0.1 nm)", km: 1e-13 },
+];

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -31,8 +31,8 @@ const categories = [
     external: false,
   },
   {
-    title: "Gaming",
-    description: "Tools, mods, and save-file tinkering for games worth tinkering with.",
+    title: "Gaming & Misc",
+    description: "Games worth tinkering with, plus interactive odds and ends that didn't fit anywhere else.",
     icon: Gamepad2,
     href: "/projects/gaming",
     external: false,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ import Projects from "./Projects";
 import CalculatorsList from "./projects/Calculators";
 import Physical from "./projects/Physical";
 import Gaming from "./projects/Gaming";
+import PiPrecision from "./projects/gaming/PiPrecision";
 import Resume from "./Resume";
 import UnitConverter from "./UnitConverter";
 import ResistiveElementSizing from "./ResistiveElementSizing";
@@ -43,6 +44,7 @@ export default function Pages() {
             />
           ))}
           <Route path="/projects/gaming" element={<Gaming />} />
+          <Route path="/projects/gaming/pi-precision" element={<PiPrecision />} />
           <Route path="/projects/calculators" element={<CalculatorsList />} />
           <Route path="/projects/calculators/unit-converter" element={<UnitConverter />} />
           <Route path="/projects/calculators/resistive-element-sizing" element={<ResistiveElementSizing />} />

--- a/src/pages/projects/Gaming.tsx
+++ b/src/pages/projects/Gaming.tsx
@@ -5,12 +5,13 @@ import { gamingProjects } from "@/data/gaming-projects";
 export default function Gaming() {
   return (
     <SimpleProjectListPage
-      title="Gaming"
+      title="Gaming & Misc"
       titleAccent="Projects"
-      description="Tools, mods, and save-file tinkering for games worth tinkering with."
+      description="Games worth tinkering with, plus interactive odds and ends that didn't fit anywhere else."
       icon={Gamepad2}
       items={gamingProjects}
       emptyMessage="Nothing published here yet — check back soon."
+      basePath="/projects/gaming"
     />
   );
 }

--- a/src/pages/projects/SimpleProjectListPage.tsx
+++ b/src/pages/projects/SimpleProjectListPage.tsx
@@ -7,6 +7,8 @@ export interface SimpleProject {
   id: string;
   title: string;
   description: string;
+  /** Combined with the page's basePath to link to an internal project page. Mutually exclusive with `url`. */
+  slug?: string;
   url?: string;
   technologies?: string[];
 }
@@ -18,9 +20,11 @@ interface SimpleProjectListPageProps {
   icon: LucideIcon;
   items: SimpleProject[];
   emptyMessage: string;
+  /** Base path used to build a link for items with a `slug` (e.g. "/projects/gaming"). */
+  basePath?: string;
 }
 
-export default function SimpleProjectListPage({ title, titleAccent, description, icon: Icon, items, emptyMessage }: SimpleProjectListPageProps) {
+export default function SimpleProjectListPage({ title, titleAccent, description, icon: Icon, items, emptyMessage, basePath }: SimpleProjectListPageProps) {
   return (
     <div className="bg-gradient-to-b from-slate-50 to-white">
       <div className="max-w-6xl mx-auto px-6 py-12">
@@ -74,6 +78,13 @@ export default function SimpleProjectListPage({ title, titleAccent, description,
                   )}
                 </div>
               );
+              if (item.slug && basePath) {
+                return (
+                  <motion.div key={item.id} initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} transition={{ duration: 0.5 }}>
+                    <Link to={`${basePath}/${item.slug}`}>{card}</Link>
+                  </motion.div>
+                );
+              }
               return item.url ? (
                 <motion.a key={item.id} href={item.url} target="_blank" rel="noopener noreferrer" initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} transition={{ duration: 0.5 }}>
                   {card}

--- a/src/pages/projects/gaming/PiPrecision.tsx
+++ b/src/pages/projects/gaming/PiPrecision.tsx
@@ -1,0 +1,58 @@
+import { lazy, Suspense } from "react";
+import { motion } from "framer-motion";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { Link } from "react-router-dom";
+
+// Kept as a separate lazily-fetched module so its data tables and math don't
+// bloat the site's main bundle for visitors who never open this page.
+const PiPrecisionExplorer = lazy(() => import("@/games/pi-precision/components/PiPrecisionExplorer"));
+
+function ExplorerLoadingFallback() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 min-h-[420px] rounded-2xl border border-dashed border-slate-700 bg-slate-950/60 text-slate-400">
+      <Loader2 className="w-6 h-6 animate-spin" />
+      <p className="text-sm">Loading the explorer&hellip;</p>
+    </div>
+  );
+}
+
+export default function PiPrecision() {
+  return (
+    <div className="bg-gradient-to-b from-slate-50 to-white">
+      <div className="max-w-5xl mx-auto px-6 py-12">
+        <div className="mb-8">
+          <Link to="/projects/gaming" className="inline-flex items-center gap-2 text-slate-600 hover:text-slate-900 transition-colors mb-6">
+            <ArrowLeft className="w-4 h-4" />
+            Back to Gaming & Misc Projects
+          </Link>
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 30 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8 }}
+          className="text-center mb-10"
+        >
+          <h1 className="text-4xl md:text-5xl font-light text-slate-900 mb-4">
+            How Much
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-indigo-600 font-medium">
+              {" "}Pi{" "}
+            </span>
+            Do You Need?
+          </h1>
+          <p className="text-lg text-slate-600 max-w-2xl mx-auto">
+            Every planetary position is computed with a value of &pi; that's been cut off somewhere. Cut it off too
+            early and a "precise" position can drift by kilometers — or light-years. See how many digits it actually
+            takes.
+          </p>
+        </motion.div>
+
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6, delay: 0.15 }}>
+          <Suspense fallback={<ExplorerLoadingFallback />}>
+            <PiPrecisionExplorer />
+          </Suspense>
+        </motion.div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds an interactive "How Much Pi Do You Need?" explorer showing how truncating pi to fewer significant digits drifts a planet's calculated orbital position, from Mercury out to the edge of the observable universe
- Generalizes the gaming project list (`gaming-projects.ts`, `SimpleProjectListPage.tsx`) to support slug-linked internal pages alongside external URLs
- Renames the "Gaming" project category to "Gaming & Misc" to make room for non-game interactive tools like this one

## Test plan
- [x] `npm run verify` (Biome lint, typecheck, build, vitest) passes, including 22 new engine tests
- [ ] Manual click-through of `/projects/gaming/pi-precision` in a browser (slider drag, target-precision picker, table results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)